### PR TITLE
Use LB for LocalAI+vLLM

### DIFF
--- a/deployments/waterboy/local-ai.yaml
+++ b/deployments/waterboy/local-ai.yaml
@@ -22,7 +22,7 @@ spec:
   selector:
     matchLabels:
       app: local-ai
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -58,8 +58,8 @@ metadata:
 spec:
   selector:
     app: local-ai
-  type: NodePort
+  type: LoadBalancer
   ports:
     - protocol: TCP
       targetPort: 8080
-      port: 8080
+      port: 80


### PR DESCRIPTION
This changes tries to use MetalLB to configure the LocalAI deployment over the public IP